### PR TITLE
Remove dynamo max get log

### DIFF
--- a/slim.js
+++ b/slim.js
@@ -431,9 +431,6 @@ DynamoTable.prototype.batchGet = function(keys, options, tables, cb) {
     }, {}))
   }
 
-  if (allKeys.length > DynamoTable.MAX_GET)
-    console.log('Alarma!!', allKeys.length)
-
   for (i = 0; i < allKeys.length; i += DynamoTable.MAX_GET) {
     requestItems = {}
     for (j = i; j < i + DynamoTable.MAX_GET && j < allKeys.length; j++) {


### PR DESCRIPTION
There is a test to ensure we're not retrieving more keys than DynamoDB
supports (250). Fortunately, PostgreSQL has no such limit. Remove the
test to prevent it from spamming production logs.